### PR TITLE
Add fourcc for 10bit/12bit/16bit YUV formats

### DIFF
--- a/Android.common.mk
+++ b/Android.common.mk
@@ -10,6 +10,8 @@ LOCAL_CFLAGS += \
 	-Wno-pointer-arith \
 	-Wno-enum-conversion
 
+LOCAL_PROPRIETARY_MODULE = true
+
 # Quiet down the build system and remove any .h files from the sources
 LOCAL_SRC_FILES := $(patsubst %.h, , $(LOCAL_SRC_FILES))
 LOCAL_EXPORT_C_INCLUDE_DIRS += $(LOCAL_PATH)

--- a/Android.mk
+++ b/Android.mk
@@ -21,6 +21,7 @@
 # IN THE SOFTWARE.
 #
 
+ifeq ($(LIBDRM_VER),intel)
 LIBDRM_COMMON_MK := $(call my-dir)/Android.common.mk
 
 LOCAL_PATH := $(call my-dir)
@@ -61,3 +62,4 @@ include $(LIBDRM_COMMON_MK)
 include $(BUILD_SHARED_LIBRARY)
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
+endif

--- a/Android.mk
+++ b/Android.mk
@@ -58,6 +58,17 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
 LOCAL_C_INCLUDES := \
         $(LOCAL_PATH)/include/drm
 
+LOCAL_COPY_HEADERS :=            \
+       xf86drm.h                \
+       include/drm/drm_fourcc.h \
+       include/drm/drm.h        \
+       include/drm/drm_mode.h   \
+       include/drm/drm_sarea.h  \
+       include/drm/i915_drm.h   \
+       intel/intel_bufmgr.h     \
+
+LOCAL_COPY_HEADERS_TO := libdrm
+
 include $(LIBDRM_COMMON_MK)
 include $(BUILD_SHARED_LIBRARY)
 

--- a/include/drm/drm_fourcc.h
+++ b/include/drm/drm_fourcc.h
@@ -142,6 +142,27 @@ extern "C" {
 #define DRM_FORMAT_NV42		fourcc_code('N', 'V', '4', '2') /* non-subsampled Cb:Cr plane */
 
 /*
+ * 2 plane YCbCr MSB aligned
+ * index 0 = Y plane, [15:0] Y:x [10:6] little endian
+ * index 1 = Cr:Cb plane, [31:0] Cr:x:Cb:x [10:6:10:6] little endian
+ */
+#define DRM_FORMAT_P010		fourcc_code('P', '0', '1', '0') /* 2x2 subsampled Cr:Cb plane 10 bits per channel */
+
+/*
+ * 2 plane YCbCr MSB aligned
+ * index 0 = Y plane, [15:0] Y:x [12:4] little endian
+ * index 1 = Cr:Cb plane, [31:0] Cr:x:Cb:x [12:4:12:4] little endian
+ */
+#define DRM_FORMAT_P012		fourcc_code('P', '0', '1', '2') /* 2x2 subsampled Cr:Cb plane 12 bits per channel */
+
+/*
+ * 2 plane YCbCr MSB aligned
+ * index 0 = Y plane, [15:0] Y little endian
+ * index 1 = Cr:Cb plane, [31:0] Cr:Cb [16:16] little endian
+ */
+#define DRM_FORMAT_P016		fourcc_code('P', '0', '1', '6') /* 2x2 subsampled Cr:Cb plane 16 bits per channel */
+
+/*
  * 3 plane YCbCr
  * index 0: Y plane, [7:0] Y
  * index 1: Cb plane, [7:0] Cb

--- a/include/drm/drm_mode.h
+++ b/include/drm/drm_mode.h
@@ -33,6 +33,14 @@
 extern "C" {
 #endif
 
+/* rotation property bits */
+#define DRM_ROTATE_0	0
+#define DRM_ROTATE_90	1
+#define DRM_ROTATE_180	2
+#define DRM_ROTATE_270	3
+#define DRM_REFLECT_X	4
+#define DRM_REFLECT_Y	5
+
 #define DRM_DISPLAY_INFO_LEN	32
 #define DRM_CONNECTOR_NAME_LEN	32
 #define DRM_DISPLAY_MODE_LEN	32

--- a/intel/Android.mk
+++ b/intel/Android.mk
@@ -32,8 +32,7 @@ LOCAL_MODULE := libdrm_intel
 LOCAL_SRC_FILES := $(LIBDRM_INTEL_FILES)
 
 LOCAL_SHARED_LIBRARIES := \
-	libdrm \
-	libpciaccess
+	libdrm
 
 include $(LIBDRM_COMMON_MK)
 include $(BUILD_SHARED_LIBRARY)

--- a/intel/intel_bufmgr.c
+++ b/intel/intel_bufmgr.c
@@ -36,7 +36,9 @@
 #include <errno.h>
 #include <drm.h>
 #include <i915_drm.h>
+#ifndef ANDROID
 #include <pciaccess.h>
+#endif
 #include "libdrm_macros.h"
 #include "intel_bufmgr.h"
 #include "intel_bufmgr_priv.h"
@@ -329,6 +331,10 @@ drm_intel_get_pipe_from_crtc_id(drm_intel_bufmgr *bufmgr, int crtc_id)
 static size_t
 drm_intel_probe_agp_aperture_size(int fd)
 {
+#ifdef ANDROID
+	/* Android does not have libpciaccess. */
+	return 64 * 1024 * 1024;
+#else
 	struct pci_device *pci_dev;
 	size_t size = 0;
 	int ret;
@@ -350,6 +356,7 @@ drm_intel_probe_agp_aperture_size(int fd)
 err:
 	pci_system_cleanup ();
 	return size;
+#endif
 }
 
 int

--- a/tests/modetest/Android.mk
+++ b/tests/modetest/Android.mk
@@ -4,6 +4,8 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/Makefile.sources
 
 LOCAL_SRC_FILES := $(MODETEST_FILES)
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/..
 
 LOCAL_MODULE := modetest
 

--- a/tests/proptest/Android.mk
+++ b/tests/proptest/Android.mk
@@ -4,6 +4,8 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/Makefile.sources
 
 LOCAL_SRC_FILES := $(PROPTEST_FILES)
+LOCAL_C_INCLUDES := \
+    $(LOCAL_PATH)/..
 
 LOCAL_MODULE := proptest
 


### PR DESCRIPTION
Those formats are used for HEVC10bit decoding
Android need gralloc these formats

Signed-off-by: Lin Johnson <johnson.lin@intel.com>