### PR TITLE
Suppress compile warnings on Android

### DIFF
--- a/libsync.h
+++ b/libsync.h
@@ -85,7 +85,8 @@ static inline int sync_wait(int fd, int timeout)
 
 static inline int sync_merge(const char *name, int fd1, int fd2)
 {
-	struct sync_merge_data data = {0};
+	struct sync_merge_data data;
+	memset(&data, 0, sizeof(struct sync_merge_data));
 	int ret;
 
 	data.fd2 = fd2;


### PR DESCRIPTION
Jira: None.
Test: Build passes on Android and no warnings reported.