### PR TITLE
Add definition for gem_acess_usrdata

### DIFF
--- a/include/drm/i915_drm.h
+++ b/include/drm/i915_drm.h
@@ -319,6 +319,7 @@ typedef struct _drm_i915_sarea {
 #define DRM_I915_PERF_ADD_CONFIG	0x37
 #define DRM_I915_PERF_REMOVE_CONFIG	0x38
 #define DRM_I915_QUERY			0x39
+#define DRM_I915_GEM_ACCESS_USERDATA   0x3c
 
 #define DRM_IOCTL_I915_INIT		DRM_IOW( DRM_COMMAND_BASE + DRM_I915_INIT, drm_i915_init_t)
 #define DRM_IOCTL_I915_FLUSH		DRM_IO ( DRM_COMMAND_BASE + DRM_I915_FLUSH)
@@ -377,6 +378,7 @@ typedef struct _drm_i915_sarea {
 #define DRM_IOCTL_I915_PERF_ADD_CONFIG	DRM_IOW(DRM_COMMAND_BASE + DRM_I915_PERF_ADD_CONFIG, struct drm_i915_perf_oa_config)
 #define DRM_IOCTL_I915_PERF_REMOVE_CONFIG	DRM_IOW(DRM_COMMAND_BASE + DRM_I915_PERF_REMOVE_CONFIG, __u64)
 #define DRM_IOCTL_I915_QUERY			DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_QUERY, struct drm_i915_query)
+#define DRM_IOCTL_I915_GEM_ACCESS_USERDATA     DRM_IOWR(DRM_COMMAND_BASE + DRM_I915_GEM_ACCESS_USERDATA, struct drm_i915_gem_access_userdata)
 
 /* Allow drivers to submit batchbuffers directly to hardware, relying
  * on the security mechanisms provided by hardware.
@@ -1234,6 +1236,21 @@ struct drm_i915_gem_get_tiling {
 	 * mmap mapping whilst bound.
 	 */
 	__u32 phys_swizzle_mode;
+};
+
+struct drm_i915_gem_access_userdata {
+       /** Handle of the buffer whose userdata will be accessed */
+       __u32 handle;
+
+       /**
+        * Userdata:  This quantity is user defined
+        */
+       __u32 userdata;
+
+       /**
+        * Write: 0=read userdata, 1=write userdata
+        */
+       __u32 write;
 };
 
 struct drm_i915_gem_get_aperture {


### PR DESCRIPTION
access userdata is kernel feature for IPC purpose
this is necesarry when usage like video deinterlace

Jira: None
Tests: Android boot and deinterlace video playback