### PR TITLE
libkms: update list of intel_drivers for Android build

### DIFF
--- a/libkms/Android.mk
+++ b/libkms/Android.mk
@@ -1,6 +1,6 @@
 DRM_GPU_DRIVERS := $(strip $(filter-out swrast, $(BOARD_GPU_DRIVERS)))
 
-intel_drivers := i915 i965 i915g ilo
+intel_drivers := i915 i965 i915g iris
 radeon_drivers := r300g r600g radeonsi
 nouveau_drivers := nouveau
 virgl_drivers := virgl


### PR DESCRIPTION
Add new iris driver, remove deprecated ilo driver.

Jira: None
Signed-off-by: Tapani Pälli <tapani.palli@intel.com>
Reviewed-by: Eric Engestrom <eric.engestrom@intel.com>