### PR TITLE
Add a API for query GVT active from kernel

### DIFF
--- a/include/drm/i915_drm.h
+++ b/include/drm/i915_drm.h
@@ -531,6 +531,8 @@ typedef struct drm_i915_irq_wait {
  */
 #define I915_PARAM_CS_TIMESTAMP_FREQUENCY 51
 
+#define I915_PARAM_IS_GVT                 55
+
 typedef struct drm_i915_getparam {
 	__s32 param;
 	/*

--- a/intel/Android.sources.bp
+++ b/intel/Android.sources.bp
@@ -9,5 +9,6 @@ cc_defaults {
         "intel_decode.c",
         "test_decode.c",
         "mm.c",
+        "intel_gvt.c",
     ],
 }

--- a/intel/Makefile.sources
+++ b/intel/Makefile.sources
@@ -5,6 +5,7 @@ LIBDRM_INTEL_FILES := \
 	intel_bufmgr_gem.c \
 	intel_decode.c \
 	intel_chipset.h \
+        intel_gvt.c \
 	mm.c \
 	mm.h \
 	uthash.h
@@ -12,4 +13,5 @@ LIBDRM_INTEL_FILES := \
 LIBDRM_INTEL_H_FILES := \
 	intel_bufmgr.h \
 	intel_aub.h \
-	intel_debug.h
+	intel_debug.h \
+        intel_gvt.h

--- a/intel/intel_gvt.c
+++ b/intel/intel_gvt.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2007 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Tang Shaofeng <shaofeng.tang@intel.com>
+ *
+ */
+
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <string.h>
+#include <errno.h>
+
+#include "i915_drm.h"
+#include "intel_gvt.h"
+
+int drm_intel_get_gvt_active(int fd, int *active)
+{
+	drm_i915_getparam_t gp;
+	int ret;
+
+	memset(&gp, 0, sizeof(gp));
+	gp.value = (int*)active;
+	gp.param = I915_PARAM_IS_GVT;
+	do {
+		ret = ioctl(fd, DRM_IOCTL_I915_GETPARAM, &gp);
+	} while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+	return ret;
+}

--- a/intel/intel_gvt.h
+++ b/intel/intel_gvt.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2011 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Tang, Shaofeng <shaofeng.tang@intel.com>
+ *
+ */
+
+#ifndef INTEL_GVT_H
+#define INTEL_GVT_H
+
+#include <stdint.h>
+#if defined(__cplusplus)
+extern "C" {
+#endif
+int drm_intel_get_gvt_active(int fd, int *active);
+
+#if defined(__cplusplus)
+}
+#endif
+#endif /* INTEL_GVT_H */

--- a/intel/meson.build
+++ b/intel/meson.build
@@ -23,7 +23,7 @@ libdrm_intel = shared_library(
   [
     files(
       'intel_bufmgr.c', 'intel_bufmgr_fake.c', 'intel_bufmgr_gem.c',
-      'intel_decode.c', 'mm.c',
+      'intel_decode.c', 'mm.c', 'intel_gvt.c'
     ),
     config_file,
   ],
@@ -41,7 +41,7 @@ ext_libdrm_intel = declare_dependency(
 )
 
 install_headers(
-  'intel_bufmgr.h', 'intel_aub.h', 'intel_debug.h',
+  'intel_bufmgr.h', 'intel_aub.h', 'intel_debug.h', 'intel_gvt.h',
   subdir : 'libdrm',
 )
 


### PR DESCRIPTION
Add a API for query if GVT is active in kernel via
the IOCTL GETPARAM

Tests: Work well for both GVT-d and GVT-g
Tracked-On: None
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>