### PR TITLE
Fix the last two arguments mis-order of memset

### DIFF
--- a/tests/util/pattern.c
+++ b/tests/util/pattern.c
@@ -643,7 +643,7 @@ void util_smpte_c8_gamma(unsigned size, struct drm_color_lut *lut)
 		printf("Error: gamma too small: %d < %d\n", size, 7 + 7 + 8);
 		return;
 	}
-	memset(lut, size * sizeof(struct drm_color_lut), 0);
+	memset(lut, 0, size * sizeof(struct drm_color_lut));
 
 #define FILL_COLOR(idx, r, g, b) \
 	lut[idx].red = (r) << 8; \


### PR DESCRIPTION
The size argument of memset function is 0. The second and third parameters are reversed.

Tests: build well
Tracked-On: OAM-94707
Signed-off-by: HeYue <yue.he@intel.com>