### PR TITLE
UPSTREAM: add crosvm to com.android.virt

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -66,4 +66,8 @@ cc_library {
         "-Wno-sign-compare",
         "-Wno-tautological-compare",
     ],
+    apex_available: [
+        "//apex_available:platform",
+        "com.android.virt",
+    ],
 }


### PR DESCRIPTION
To do so, crosvm and its dependencies have the apex_available property
set to "//apex_available:platform", "com.android.virt" to explicitly
acknowledge the joining.

Bug: 174639241
Test: m com.android.virt

Tracked-On: OAM-99755
Signed-off-by: Jiyong Park <jiyong@google.com>
Change-Id: Idd7706a931fde0dfd77fe8b58f6f0c84081c6e3c