### PR TITLE
Add virtio ioctl parameters needed for ivshmem detection .

### DIFF
--- a/include/drm/virtgpu_drm.h
+++ b/include/drm/virtgpu_drm.h
@@ -71,6 +71,8 @@ struct drm_virtgpu_execbuffer {
 
 #define VIRTGPU_PARAM_3D_FEATURES 1 /* do we have 3D features in the hw */
 #define VIRTGPU_PARAM_CAPSET_QUERY_FIX 2 /* do we have the capset fix */
+#define VIRTGPU_PARAM_RESOURCE_BLOB 3 /* DRM_VIRTGPU_RESOURCE_CREATE_BLOB */
+#define VIRTGPU_PARAM_QUERY_DEV 11 /* Query the virtio device name. */
 
 struct drm_virtgpu_getparam {
 	__u64 param;


### PR DESCRIPTION
Addtionally need read VIRTGPU_PARAM_RESOURCE_BLOB.

Add DRM_VIRTGPU_RESOURCE_CREATE_BLOB &
        DRM_VIRTGPU_PARAM_QUERY_DEV

Tracked-On: OAM-129380